### PR TITLE
商品関連ページのヘッダー・フッターのフロント実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,5 +13,7 @@
 // .scssを削除しました
 @import "header";
 @import "footer";
+@import "item-header";
+@import "item-footer";
 @import "font-awesome-sprockets";
 @import "font-awesome";

--- a/app/assets/stylesheets/item-footer.scss
+++ b/app/assets/stylesheets/item-footer.scss
@@ -1,0 +1,37 @@
+.footer {
+  background-color:rgb(245, 245, 245);
+  height: 220px;
+  margin: 0 auto;
+  text-align: center;
+  display: block;
+  padding:40px 0 41px 0;
+  &__list {
+    height: 54px;
+    ul {
+      height: 14px;
+      margin: 0 auto;
+      display: -webkit-flex;
+      justify-content: center;
+      li {
+        margin: 0px 0px 0px 16px;
+        a {
+          text-decoration: none;
+          font-size: 12px;
+          color: rgb(51, 51, 51);
+            &:hover {
+              opacity: 0.7;
+              text-decoration: underline;
+            } 
+        }
+      }
+    } 
+  }
+  img {
+    filter: brightness(1) invert(25%);
+  }
+  p {
+    font-size: 13px;
+    color: rgb(51, 51, 51);
+    padding-top: 10px;
+  }
+}   

--- a/app/assets/stylesheets/item-header.scss
+++ b/app/assets/stylesheets/item-header.scss
@@ -1,0 +1,15 @@
+.header {
+  background-color:rgb(245, 245, 245);
+  height: 128px;
+  width: 100%;
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  &__img {
+    display: block;
+    width: 185px;
+    height: 49px;
+    line-height: 49px;
+    margin: 0 auto;
+  }
+}

--- a/app/assets/stylesheets/purchase_temporary.scss
+++ b/app/assets/stylesheets/purchase_temporary.scss
@@ -1,8 +1,8 @@
 .main {
   background-color:rgb(245, 245, 245);
-  height: 1450px;
+  //height: 1450px; フッターの部分テンプレートを入れたため削除 6/4山中
   width: 100%;
-  padding-top: 200px;
+  //padding-top: 200px; ヘッダーの部分テンプレートを入れたため削除 6/4山中
   color:#333333;
   &__body { 
     width: 700px;

--- a/app/views/items/_item-footer.html.haml
+++ b/app/views/items/_item-footer.html.haml
@@ -1,0 +1,14 @@
+.footer
+  .footer__list
+    %ul 
+      %li
+        = link_to "プライバシーポリシー" 
+      %li
+        = link_to "フリマ利用規約" 
+      %li
+        = link_to "特定商取引に関する表記" 
+  .footer__logo
+    = link_to root_path do
+      .footer__img
+        = image_tag "material/logo/logo-white.png", size: "115x30"
+    %p © Furima, Inc.

--- a/app/views/items/_item-header.html.haml
+++ b/app/views/items/_item-header.html.haml
@@ -1,0 +1,3 @@
+.header
+  = link_to root_path do
+    = image_tag "material/logo/logo.png", class: "header__img", size: "200x58"

--- a/app/views/items/purchase_temporary.html.haml
+++ b/app/views/items/purchase_temporary.html.haml
@@ -1,3 +1,5 @@
+.wrapper
+  = render 'item-header'
 .main
   .main__body
     .main__body__top
@@ -47,3 +49,5 @@
     .main__body__purchase
       .main__body__purchase__box
         購入する
+.wrapper
+  = render 'item-footer'


### PR DESCRIPTION
#What
商品関連ページのヘッダーとフッターのフロント実装

#why
アプリの見た目を整えるため
部分テンプレートできるように

#comment
木下さんのヘッダー・フッター部分にあたるpaddingなど
消去（コメントアウト）させていただきました。