### PR TITLE
update-classname

### DIFF
--- a/app/assets/stylesheets/item-header.scss
+++ b/app/assets/stylesheets/item-header.scss
@@ -1,4 +1,4 @@
-.header {
+.header-item {
   background-color:rgb(245, 245, 245);
   height: 128px;
   width: 100%;

--- a/app/views/items/_item-header.html.haml
+++ b/app/views/items/_item-header.html.haml
@@ -1,3 +1,3 @@
-.header
+.header-item
   = link_to root_path do
     = image_tag "material/logo/logo.png", class: "header__img", size: "200x58"


### PR DESCRIPTION
#what
商品関連ページのヘッダーのクラス名の変更

#why
トップページと商品関連ページのヘッダーのクラス名が同じだったため、SCSSが狙い通りに当たっていなかったので、名前を変更しました。