### PR TITLE
update-classname-2

### DIFF
--- a/app/assets/stylesheets/item-footer.scss
+++ b/app/assets/stylesheets/item-footer.scss
@@ -1,4 +1,4 @@
-.footer {
+.footer-item {
   background-color:rgb(245, 245, 245);
   height: 220px;
   margin: 0 auto;

--- a/app/views/items/_item-footer.html.haml
+++ b/app/views/items/_item-footer.html.haml
@@ -1,4 +1,4 @@
-.footer
+.footer-item
   .footer__list
     %ul 
       %li


### PR DESCRIPTION
#what
商品関連ページのフッターのクラス名の変更

#why
トップページと商品関連ページのフッターのクラス名が同じだったため、SCSSが狙い通りに当たっていなかったので、名前を変更しました。