### PR TITLE
ユーザー新規登録の送付先氏名情報追加

### DIFF
--- a/app/assets/stylesheets/sign_up.scss
+++ b/app/assets/stylesheets/sign_up.scss
@@ -127,6 +127,7 @@
         margin-left: auto;
         margin-right: auto;
         margin-top: 10px;
+        margin-bottom: 50px;
         border-radius: 5px;
         text-align: center; 
         border-style: none;                

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
   # sign_upアクションに対して各キーをパラメーターで許可する6/14木下
   protected
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :first_name,:family_name, :first_name_kana, :family_name_kana, :birth_year, :birth_month, :birth_day, :post_code, :prefecture_code, :city, :house_number, :building_name, :phone_number])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :first_name,:family_name, :first_name_kana, :family_name_kana, :birth_year, :birth_month, :birth_day, :post_code, :prefecture_code, :city, :house_number, :building_name, :phone_number,:destination_first_name,:destination_family_name, :destination_first_name_kana, :destination_family_name_kana])
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,7 @@ class User < ApplicationRecord
 
 
   validates :family_name, :first_name, :family_name_kana, :first_name_kana, :birth_year, :birth_month, :birth_day ,:post_code ,:prefecture_code , :city, :house_number,  :destination_first_name,:destination_family_name, :destination_first_name_kana, :destination_family_name_kana,presence: true
-  # validates :email, uniqueness: true
+ 
  
   has_many :items, dependent: :destroy 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,12 +9,25 @@ class User < ApplicationRecord
   validates :family_name, format: {with: /\A[ぁ-んァ-ン一-龥]/  }
   validates :first_name, format: {with: /\A[ぁ-んァ-ン一-龥]/  }
  
+
   
+  # 送付先関連本名は全角で入力させる(全角ひらがな、全角カタカナ、漢字) 7/11木下
+  validates :destination_family_name, format: {with: /\A[ぁ-んァ-ン一-龥]/  }
+  validates :destination_first_name, format: {with: /\A[ぁ-んァ-ン一-龥]/  }
+  
+
+
   # ユーザー本名のふりがなは全角で入力させる (全角カタカナ) 6/15木下      
   validates :family_name_kana, format: {with: /\A[ァ-ヶー－]+\z/  }
   validates :first_name_kana, format: {with: /\A[ァ-ヶー－]+\z/  }
   
-  
+
+
+  # 送付先関連のふりがなは全角で入力させる (全角カタカナ) 7/11木下
+  validates :destination_family_name_kana, format: {with: /\A[ァ-ヶー－]+\z/  }
+  validates :destination_first_name_kana, format: {with: /\A[ァ-ヶー－]+\z/  }
+
+
 
   # メールアドレス@以降のドメイン必須 6/15木下
   validates :email, format: {with: /\A\S+@\S+\.\S+\z/ }
@@ -24,7 +37,7 @@ class User < ApplicationRecord
   validates :nickname, presence: true, length: { maximum: 6 }
 
 
-  validates :family_name, :first_name, :family_name_kana, :first_name_kana, :birth_year, :birth_month, :birth_day ,:post_code ,:prefecture_code , :city, :house_number, presence: true
+  validates :family_name, :first_name, :family_name_kana, :first_name_kana, :birth_year, :birth_month, :birth_day ,:post_code ,:prefecture_code , :city, :house_number,  :destination_first_name,:destination_family_name, :destination_first_name_kana, :destination_family_name_kana,presence: true
   # validates :email, uniqueness: true
  
   has_many :items, dependent: :destroy 

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -80,6 +80,42 @@
 
 
 
+
+
+          .field 
+            = f.label :送付先氏名（苗字） ,class:"field__title"
+            %span.field__must 必須
+            %span.field__text 全角
+            %br/
+            = f.text_field :destination_family_name, class:  "field__box"
+
+          .field 
+            = f.label :送付先氏名（名前）,class:"field__title"
+            %span.field__must 必須
+            %span.field__text 全角
+            %br/
+            = f.text_field :destination_first_name, class:  "field__box"
+
+          
+
+          .field 
+            = f.label :送付先氏名（ミョウジ）,class:"field__title"
+            %span.field__must 必須
+            %span.field__text 全角カタカナ
+            %br/
+            = f.text_field :destination_family_name_kana,class:  "field__box"
+          
+          .field 
+            = f.label :送付先氏名（ナマエ） ,class:"field__title"
+            %span.field__must 必須
+            %span.field__text 全角カタカナ
+            %br/
+            = f.text_field :destination_first_name_kana, class:  "field__box"         
+
+
+
+
+
           = f.label :生年月日,class:"field_mini__box__title"
           %span.field_mini__box__must 必須
           .field_mini

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -22,6 +22,11 @@ ja:
         building_name : "ビル名"
         phone_number : "電話番号"
 
+        destination_first_name: "送付先氏名（苗字）"
+        destination_family_name: "送付先氏名（名前）"
+        destination_first_name_kana: "送付先氏名（ミョウジ） "
+        destination_family_name_kana: "送付先氏名（ナマエ）"
+
 
 
     models:

--- a/db/migrate/20200523134432_devise_create_users.rb
+++ b/db/migrate/20200523134432_devise_create_users.rb
@@ -23,6 +23,12 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
       t.string :building_name
       t.string :phone_number
       t.timestamps null: false
+
+      # 送付先氏名を追加しました7/11木下
+      t.string :destination_family_name,                 null:false
+      t.string :destination_first_name,                  null:false
+      t.string :destination_family_name_kana,            null:false
+      t.string :destination_first_name_kana,             null:false
     end
     add_index :users, :email,                unique: true
     add_index :users, :reset_password_token, unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -76,6 +76,10 @@ ActiveRecord::Schema.define(version: 2020_06_06_033805) do
     t.string "phone_number"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "destination_family_name", null: false
+    t.string "destination_first_name", null: false
+    t.string "destination_family_name_kana", null: false
+    t.string "destination_first_name_kana", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -18,6 +18,12 @@ FactoryBot.define do
     prefecture_code       {"東京都"}
     city                  {"渋谷区"}
     house_number          {"1ー1ー1"}
+
+    destination_family_name           {"佐藤"}
+    destination_first_name            {"椿"}  
+    destination_family_name_kana      {"サトウ"}
+    destination_first_name_kana       {"ツバキ"}
+
   end
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -85,7 +85,7 @@ describe User do
     it "passwordが存在してもpassword_confirmationがない場合は登録できないこと" do
       user = build(:user, password_confirmation: "")
       user.valid?
-      expect(user.errors[:password_confirmation]).to include("とPasswordの入力が一致しません")
+      expect(user.errors[:password_confirmation]).to include("とパスワードの入力が一致しません")
     end
 
     #文字数制限のある項目のチェック    
@@ -278,6 +278,174 @@ describe User do
       expect(user).to be_valid 
     end
 
+    
+
+
+
+
+
+    # 送付先氏名関連　7/11木下
+
+    # destination_family_name（送付先氏名の苗字）は全角ひらがな・漢字・カタカナであること
+    it 'destination_family_nameが全角であること（半角カナではない）' do
+      user = build(:user, destination_family_name: "ｱｱ")
+      user.valid?
+      expect(user.errors[:destination_family_name]).to include("は不正な値です")
+    end
+
+    it 'destination_family_nameが全角であること（半角英語ではない）' do
+      user = build(:user, destination_family_name: "aa")
+      user.valid?
+      expect(user.errors[:destination_family_name]).to include("は不正な値です")
+    end
+ 
+    it 'destination_family_nameが全角であること（半角数字ではない）' do
+      user = build(:user, destination_family_name: "11")
+      user.valid?
+      expect(user.errors[:destination_family_name]).to include("は不正な値です")
+    end
+ 
+    it 'destination_family_nameが全角であること（全角数字ではない）' do
+      user = build(:user, destination_family_name: "２２２")
+      user.valid?
+      expect(user.errors[:destination_family_name]).to include("は不正な値です")
+    end
+ 
+    it 'destination_family_nameが全角ひらがなであれば登録できる' do
+      user = build(:user, destination_family_name: "ああ")     
+      expect(user).to be_valid 
+    end
+   
+    it 'destination_family_nameが全角漢字であれば登録できる' do
+      user = build(:user, destination_family_name: "嗚呼")     
+      expect(user).to be_valid 
+    end
+
+    it 'destination_family_nameが全角カタカナであれば登録できる' do
+      user = build(:user, destination_family_name: "アア")     
+      expect(user).to be_valid 
+    end
+
+
+
+    # fdestination_irst_name（送付先氏名の名前）は全角ひらがな・漢字・カタカナであること
+    it 'destination_first_nameが全角であること（半角カナではない）' do
+      user = build(:user, destination_first_name: "ｲｲ")
+      user.valid?
+      expect(user.errors[:destination_first_name]).to include("は不正な値です")
+    end
+
+    it 'destination_first_nameが全角であること（半角英語ではない）' do
+      user = build(:user, destination_first_name: "ee")
+      user.valid?
+      expect(user.errors[:destination_first_name]).to include("は不正な値です")
+    end
+
+    it 'destination_first_nameが全角であること（半角数字ではない）' do
+      user = build(:user, destination_first_name: "11")
+      user.valid?
+      expect(user.errors[:destination_first_name]).to include("は不正な値です")
+    end
+
+    it 'destination_first_nameが全角であること（全角数字ではない）' do
+      user = build(:user, destination_first_name: "１１")
+      user.valid?
+      expect(user.errors[:destination_first_name]).to include("は不正な値です")
+    end
+
+    it 'destination_first_nameが全角ひらがなであれば登録できる' do
+      user = build(:user, destination_first_name: "ああ")     
+      expect(user).to be_valid 
+    end
+
+    it 'destination_first_nameが全角漢字であれば登録できる' do
+      user = build(:user, destination_first_name: "嗚呼")     
+      expect(user).to be_valid 
+    end
+
+    it 'destination_first_nameが全角カタカナであれば登録できる' do
+      user = build(:user, destination_first_name: "アア")     
+      expect(user).to be_valid 
+    end
+
+
+
+    # destination_family_name_kana（送付先氏名の苗字ふりがな）は全角カタカナのみ
+    it 'destination_family_name_kana,が全角カタカナであること（半角カナではない）' do
+      user = build(:user, destination_family_name_kana: "ｱｱ")
+      user.valid?
+      expect(user.errors[:destination_family_name_kana,]).to include("は不正な値です")
+    end
+
+    it 'destination_family_name_kana,が全角カタカナであること（ひらがなではない）' do
+      user = build(:user, destination_family_name_kana: "ああ")
+      user.valid?
+      expect(user.errors[:destination_family_name_kana,]).to include("は不正な値です")
+    end
+
+    it 'destination_family_name_kana,が全角カタカナであること（全角英語ではない）' do
+      user = build(:user, destination_family_name_kana: "ｒｑ")
+      user.valid?
+      expect(user.errors[:destination_family_name_kana,]).to include("は不正な値です")
+    end
+
+    it 'destination_family_name_kana,が全角カタカナであること（半角英語ではない）' do
+      user = build(:user, destination_family_name_kana: "aa")
+      user.valid?
+      expect(user.errors[:destination_family_name_kana,]).to include("は不正な値です")
+    end
+
+    it 'destination_family_name_kana,が全角カタカナであること（数字ではない）' do
+      user = build(:user, destination_family_name_kana: "22")
+      user.valid?
+      expect(user.errors[:destination_family_name_kana,]).to include("は不正な値です")
+    end
+
+    it 'destination_family_name_kanaが全角カタカナであれば登録できる' do
+      user = build(:user, destination_family_name_kana: "アア")     
+      expect(user).to be_valid 
+    end
+
+
+
+    # destination_first_name_kana（送付先氏名の名前ふりがな）は全角カタカナのみ
+    it 'destination_first_name_kanaが全角カタカナであること（半角カナではない）' do
+      user = build(:user, destination_first_name_kana: "ｲｲ")
+      user.valid?
+      expect(user.errors[:destination_first_name_kana]).to include("は不正な値です")
+    end
+
+    it 'destination_first_name_kanaが全角カタカナであること（ひらがなではない）' do
+      user = build(:user, destination_first_name_kana: "いい")
+      user.valid?
+      expect(user.errors[:destination_first_name_kana]).to include("は不正な値です")
+    end
+
+    it 'destination_first_name_kanaが全角カタカナであること（全角英語ではない）' do
+      user = build(:user, destination_first_name_kana: "ｒｑ")
+      user.valid?
+      expect(user.errors[:destination_first_name_kana]).to include("は不正な値です")
+    end
+
+    it 'destination_first_name_kanaが全角カタカナであること（半角英語ではない）' do
+      user = build(:user, destination_first_name_kana: "EE")
+      user.valid?
+      expect(user.errors[:destination_first_name_kana]).to include("は不正な値です")
+    end
+
+    it 'destination_first_name_kanaが全角カタカナであること（数字ではない）' do
+      user = build(:user, destination_first_name_kana: "11")
+      user.valid?
+      expect(user.errors[:destination_first_name_kana]).to include("は不正な値です")
+    end
+
+    it 'destination_first_name_kanaが全角カタカナであれば登録できる' do
+      user = build(:user, destination_first_name_kana: "イイ")     
+      expect(user).to be_valid 
+    end
+
+ 
+      
   end
 end
 


### PR DESCRIPTION
# What
- フロント
  - 送付先氏名苗字
  - 送付先氏名名前
  - 送付先氏名苗字（フリガナ）
  - 送付先氏名名前（フリガナ）
https://gyazo.com/c476dfc854bb8658f453f1f755a1ee7d

- バリデーションとテストコードクリア済み
https://gyazo.com/6bdc1e86d2c0c6c7f47057f9c4769274

# Why
必須項目であるが、実装を失念していたため
そのほかの新規登録箇所はメンターLGTMをもらっております。

# メンバー各位
userテーブルにdestination追加しています。