### PR TITLE
出品中/売却済みなどの状態の登録

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -19,7 +19,7 @@ class Item < ApplicationRecord
   
 
   belongs_to :seller, class_name: "User", foreign_key: 'seller_id'
-  belongs_to :buyer_item, class_name:"User", optional: true
+  belongs_to :buyer, class_name:"User", optional: true, foreign_key: 'buyer_id'
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :prefecture, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,4 +41,9 @@ class User < ApplicationRecord
  
  
   has_many :items, dependent: :destroy 
+
+  has_many :buyed_items, foreign_key: "buyer_id", class_name: "Item"
+  has_many :saling_items, -> { where("buyer_id is NULL") }, foreign_key: "seller_id", class_name: "Item"
+  has_many :sold_items, -> { where("buyer_id is not NULL") }, foreign_key: "seller_id", class_name: "Item"
+  
 end


### PR DESCRIPTION
# What
出品中/売却済みなどの状態の登録、データの取り出しができるように実装

# Why
buyed_items：userが「買った」商品 
saling_items：userが 「現在売っている」商品
sold_items   ：userが「既に売った」商品
として、商品の販売状態を実装することはフリマアプリ に必須の機能のため

# コメント
情報が取れているかコンソールで確認しました。

【前提条件としてDB】
- Users
https://gyazo.com/ec59921f8e1b5516b2357bda5d831839

- Items
https://gyazo.com/adb7a5a168f7657aa81ab45b8d0e83bf

【ターミナル】
https://gyazo.com/1c7dcaf9d53f6e1f27a73990b9069887
https://gyazo.com/3a920cc21e847317878f5be0a7c779c8