### PR TITLE
商品詳細カテゴリー名

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -32,6 +32,12 @@
         %tr
           %th.main__informations__information__item カテゴリー
           %td.main__informations__information__breakdown
+            =@item.category.parent.parent.name
+            %br
+            = icon("fas", "angle-right", class: "icon-angle-right")
+            =@item.category.parent.name
+            %br
+            = icon("fas", "angle-right", class: "icon-angle-right")
             =@item.category.name
         %tr
           %th.main__informations__information__item  ブランド


### PR DESCRIPTION
# What
商品詳細ページのカテゴリー名を、親カテゴリ、子カテゴリ、孫カテゴリ全て表示させる
https://gyazo.com/d8c38fd7e7ca99a9a9b96184c905ba70

# Why
アプリ作成のため