### PR TITLE
新規登録ラベル修正2点、購入確認ボタン修正

### DIFF
--- a/app/assets/stylesheets/purchase_temporary.scss
+++ b/app/assets/stylesheets/purchase_temporary.scss
@@ -169,6 +169,7 @@
         font-size: 15px;        
         font-weight: bolder;
         color: white;
+        border-radius: 5px;
       }
     }
   }

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -142,13 +142,13 @@
             = f.text_field :post_code,placeholder: "xxx-xxxx", class:  "field__box"
           
           .field 
-            = f.label :県,class:"field__title"
+            = f.label :都道府県,class:"field__title"
             %span.field__must 必須
             %br/
             = f.text_field :prefecture_code,placeholder: "東京都", class:  "field__box"
 
           .field 
-            = f.label :住所,class:"field__title"
+            = f.label :市区町村,class:"field__title"
             %span.field__must 必須
             %br/
             = f.text_field :city,placeholder: "渋谷区渋谷町", class:  "field__box"


### PR DESCRIPTION
# what
フロント実装の精度を上げるため

# why
・県▶︎都道府県
・住所▶︎市区町村
・購入ページのボタンの角丸く

購入ページのサーバーサイドはこの後直します。

https://gyazo.com/6482125d853b6e1565220ca8c8cb2b5e
https://gyazo.com/470328d4fc5eb218c719140397fbc860