### PR TITLE
【WIP】購入確認ページ修正

### DIFF
--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -7,8 +7,7 @@ class CreditCardsController < ApplicationController
   end
 
   def pay #payjpとCardのデータベース作成を実施します。
-    # Payjp.api_key =/ENV["PAYJP_PRIVATE_KEY"]
-    Payjp.api_key = 'sk_test_8c736d594af0a588864c727b'
+    Payjp.api_key =/ENV["PAYJP_PRIVATE_KEY"]
 
     if params['payjp-token'].blank?
 
@@ -36,8 +35,7 @@ class CreditCardsController < ApplicationController
     card = CreditCard.find_by(user_id: current_user.id)
     if card.blank?
     else
-      # Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
-      Payjp.api_key = 'sk_test_8c736d594af0a588864c727b'
+      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
       customer = Payjp::Customer.retrieve(card.customer_id)
       customer.delete
       card.delete

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -76,7 +76,7 @@ class ItemsController < ApplicationController
       redirect_to pay_credit_cards_path
     else
       Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
-    
+      
       customer = Payjp::Customer.retrieve(card.customer_id)
       
       @default_card_information = customer.cards.retrieve(card.card_id)

--- a/app/views/items/purchase_index.html.haml
+++ b/app/views/items/purchase_index.html.haml
@@ -1,61 +1,64 @@
-.wrapper
-  = render 'items/item-header'
-.main
-  .main__body
-    .main__body__top
-      購入内容の確認
-    .main__body__item    
-      = image_tag('material/pict/pict-reason-01.jpg', class:"main__body__item__img")
-      .main__body__item__explanation
-        .main__body__item__explanation__text
-          サファイアリング♡7号 美品【エテ】K10 サファイア デザインリング☆アガット 
-        .main__body__item__explanation__price
-          10,900 （税込）送料込み     
+-# 最後で消します。購入確認の旧ページ。高松さんがこのページで購入を設定してくれた　7/23木下
 
-    .main__body__price
-      .main__body__price__text
-        支払い金額
-      .main__body__price__price
-        ￥1,000   
+-# .wrapper
+-#   = render 'items/item-header'
+-# .main
+-#   .main__body
+-#     .main__body__top
+-#       購入内容の確認
+-#     .main__body__item    
+-#       = image_tag('material/pict/pict-reason-01.jpg', class:"main__body__item__img")
+-#       .main__body__item__explanation
+-#         .main__body__item__explanation__text
+-#           サファイアリング♡7号 美品【エテ】K10 サファイア デザインリング☆アガット 
+-#         .main__body__item__explanation__price
+-#           10,900 （税込）送料込み     
 
-    .main__body__method_payment
-      .main__body__method_payment__list
-        .main__body__method_payment__list__title
-          支払い方法
-        .main__body__method_payment__list__card
-          クレジットカード
-        .main__body__method_payment__list__number
-          0000-0000-0000-0000
-        .main__body__method_payment__list__expiration_date
-          04/24
-        .main__body__method_payment__list__card_type       
-          = icon('fab', 'cc-visa fa-2x')           
-      .main__body__method_payment__edit
-        変更する
+-#     .main__body__price
+-#       .main__body__price__text
+-#         支払い金額
+-#       .main__body__price__price
+-#         ￥1,000   
 
-    .main__body__shipping_address
-      .main__body__shipping_address__list        
-        .main__body__shipping_address__list__title
-          配送先
-        .main__body__shipping_address__list__postal_code
-          〒000-0000
-        .main__body__shipping_address__list__address
-          東京都千代田区日本橋1-1-1
-        .main__body__shipping_address__list__name
-          国分 太郎        
-      .main__body__shipping_address__edit
-        変更する     
+-#     .main__body__method_payment
+-#       .main__body__method_payment__list
+-#         .main__body__method_payment__list__title
+-#           支払い方法
+-#         .main__body__method_payment__list__card
+-#           クレジットカード
+-#         .main__body__method_payment__list__number
+-#           0000-0000-0000-0000
+-#         .main__body__method_payment__list__expiration_date
+-#           04/24
+-#         .main__body__method_payment__list__card_type       
+-#           = icon('fab', 'cc-visa fa-2x')           
+-#       .main__body__method_payment__edit
+-#         変更する
 
-    .main__body__purchase
-      .main__body__purchase__box
-        = form_tag(action: :pay, method: :post) do
-          %button 購入する
-        -# = link_to "/items/pay/#{params[:id]}" , method: :post
-.wrapper
-  = render 'items/item-footer'
+-#     .main__body__shipping_address
+-#       .main__body__shipping_address__list        
+-#         .main__body__shipping_address__list__title
+-#           配送先
+-#         .main__body__shipping_address__list__postal_code
+-#           〒000-0000
+-#         .main__body__shipping_address__list__address
+-#           東京都千代田区日本橋1-1-1
+-#         .main__body__shipping_address__list__name
+-#           国分 太郎        
+-#       .main__body__shipping_address__edit
+-#         変更する     
 
-
-
-
+-#     .main__body__purchase
+-#       .main__body__purchase__box
+-#         = form_tag(action: :pay, method: :post) do
+-#           %button 購入する
+-#         -# = link_to "/items/pay/#{params[:id]}" , method: :post
+-# .wrapper
+-#   = render 'items/item-footer'
 
 
+
+
+
+
+-# aaaaaaaaaaa

--- a/app/views/items/purchase_temporary.html.haml
+++ b/app/views/items/purchase_temporary.html.haml
@@ -58,7 +58,11 @@
 
     .main__body__purchase
       .main__body__purchase__box
-        = link_to "/purchase/done/#{@item}" do
+        = form_tag(action: :pay, method: :post) do
+          %button 購入する
+        
+        -# 動作に問題ないことを確認して最後に消します７・23木下
+        -# = link_to "/purchase/done/#{@item}" do
           購入する
 
 .wrapper

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -71,9 +71,13 @@
     - else user_signed_in? && current_user.id != @item.seller_id
       .main__buy-button
 
+        -# 動作を確認して最後に消す7/23木下
         -# 以下のprefixを使うとエラー発生
         -# = link_to "購入画面に進む", purchase_index_items_path(@item.id), method: :get
-        = link_to "購入画面に進む", "/items/purchase_index/#{@item.id}", method: :get
+        -# = link_to "購入画面に進む", "/items/purchase_index/#{@item.id}", method: :get
+
+        -# 以下正しいページ遷移へ修正木下7/23
+        = link_to "購入画面に進む", purchase_temporary_item_path, method: :get
 
       
     .main__messages


### PR DESCRIPTION
# what
高松さんがマージしてくださったのが旧購入確認ページにリンク飛んでましたので修正
細かいビュー崩れありますが次の実装で直します。

# why
購入画面ボタンのリンク修正（下記箇所）
https://gyazo.com/5787cd951388a06079543c9db5e6bf72

購入確認ページ遷移
https://gyazo.com/6a89c48c7a5fff684bd2acddcfb7a255

購入確認完了
https://gyazo.com/f5d4fec7fb5067c23b711c3557b8c5ef