### PR TITLE
マイページのView崩れの直し

### DIFF
--- a/app/assets/stylesheets/mypage-card-create.scss
+++ b/app/assets/stylesheets/mypage-card-create.scss
@@ -111,6 +111,7 @@
   background: #ea352d;
   color: white;
   border: none;
+  border-radius: 5px;
 }
 
 .delete{

--- a/app/assets/stylesheets/mypage-logout.scss
+++ b/app/assets/stylesheets/mypage-logout.scss
@@ -8,6 +8,7 @@
   text-align: center;
   text-decoration: none;
   border-radius: 5px;
+  width: 300px;
   &--icon {
     margin: 16px;
   }
@@ -35,6 +36,9 @@
       &__inner {
         border-top: 1px solid #f5f5f5;
         height: 160px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
         &__settings-add-card {
           &__single-content {
             max-width: 320px;

--- a/app/assets/stylesheets/mypage.scss
+++ b/app/assets/stylesheets/mypage.scss
@@ -65,7 +65,7 @@
           }
           &__name {
             margin: 8px 0 0;
-            font-size: 14px;
+            font-size: 20px;
           }
         }
       }


### PR DESCRIPTION
# what
1. ユーザーネームの字を少し大きくして見やすくした
2. 削除するボタンの角を丸くした
3. 崩れてボタンが上部になっていたのを中央にした

# why
見栄えをよくするため

# 実装動画
https://gyazo.com/f756dfff02bb13a283482bb1251082a9
ご確認いただいて、2人からLGTMをもらえたら、マージしたいと思います。
（直しなので、メンターレビューなし）
よろしくお願いいたします。