### PR TITLE
送料込み・別の場合分け

### DIFF
--- a/app/views/items/done.html.haml
+++ b/app/views/items/done.html.haml
@@ -15,7 +15,10 @@
       %p.purchase-box__complete__3 
         ￥
         = @item.price
-        %span.tax (送料込み)
+        - if @item.postage_payers == "送料込み（配送者負担）"
+          %span.tax 送料込み
+        - else 
+          %span.tax 送料別
       .back-sold__btn
         %a.back-new__botton 
           = link_to "/"  do


### PR DESCRIPTION
すべて送料込みの表示だったので、
着払いの時は『送料別』と表示されるように訂正

【実装動画】
https://gyazo.com/74a61db0aa99bc17f23d71369e4b8617

LGTM２名いただけたら、メンターレビューなしでマージ予定です。
よろしくお願いいたします。