### PR TITLE
カード未登録で購入時のエラーハンドリング

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -131,10 +131,14 @@ class ItemsController < ApplicationController
 
   def purchase_temporary
     card = CreditCard.find_by(user_id: current_user.id)
-    customer = Payjp::Customer.retrieve(card.customer_id)
-    @default_card_information = customer.cards.retrieve(card.card_id)
-    @item = Item.find(params[:id])
-
+    if card.blank?
+      flash[:card] = "購入する際は クレジットカードを登録してください。"
+      redirect_to pay_credit_cards_path
+    else
+      customer = Payjp::Customer.retrieve(card.customer_id)
+      @default_card_information = customer.cards.retrieve(card.card_id)
+      @item = Item.find(params[:id])
+    end
   end
 
   def item_details   

--- a/app/views/items/_header.html.haml
+++ b/app/views/items/_header.html.haml
@@ -28,16 +28,3 @@
             ログイン
           = link_to new_user_registration_path, class:"box__select__right__new" do
             新規会員登録
-
-
-        -# - if user_signed_in?         
-        -#   = link_to "#", class: "box-part__select__right__new" do
-        -#     マイページ
-        -#   = link_to "#", method: :delete, class: "box-part__select__right__new" do
-        -#     ログアウト
-        -# - else
-        -#   -# ここのリンクは仮ルーティング木下6/5
-        -#   = link_to login_items_path, class:"box-part__select__right__login" do
-        -#     ログイン
-        -#   = link_to sign_up_items_path, class:"box-part__select__right__new" do
-        -#     新規会員登録

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -20,5 +20,9 @@
     - if flash[:alert]
       .alert
         = flash[:alert]
+    
+    - if flash[:card]
+      .alert
+        = flash[:card]
 
     = yield


### PR DESCRIPTION
# what
カード未登録で『購入画面に進む』ボタンをクリックすると、エラーになってしまい、購入時のカード未登録の場合のエラーハンドリングがもれていたので、実装を加えた

# why
フリマアプリケーションにおいて、必須の実装のため

# コメント
【実装動画】
https://gyazo.com/ec9e568daf5440c169bd27084ae30871
