### PR TITLE
update_edit_errorhandling & remove console.log

### DIFF
--- a/app/assets/javascripts/category_handling.js
+++ b/app/assets/javascripts/category_handling.js
@@ -2,7 +2,6 @@ $(function(){
   if(window.document.location.href == "http://localhost:3000/items" && $(".box-new__category__wrapper-select")[0]){
     // if(window.document.location.href == "http://localhost:3000/items" && $('.select-category')[0]){}
   // カテゴリーセレクトボックスのオプションを作成
-  console.log("aaa")
   function appendOption(category){
     let html = `<option value="${category.id}" data-category="${category.name}">${category.name}</option>`;
     return html;

--- a/app/assets/javascripts/new.js
+++ b/app/assets/javascripts/new.js
@@ -54,7 +54,6 @@ $(function() {
           fileIndex.shift();
           fileIndex.push(fileIndex[fileIndex.length - 1] + 1);
     }
-    console.log(buildFileField)
   });
   $('#prev-box').on('click', '.box-new__pic__prev__wrapper__delete', function(e) {
     const targetIndex = $(this).data('index');

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -68,7 +68,7 @@ class ItemsController < ApplicationController
       redirect_to root_path
       else
         flash[:alert] = "入力に誤りがあります。もう一度入力してください。"
-        render :edit
+        redirect_to action: :edit
     end
   end
   


### PR DESCRIPTION
# What
画像を追加・削除し、他の項目で未入力で変更ボタンを押す
　　↓　エラーハンドリング
再度入力画面が表示される
すでに削除した画像も追加された画像も表示されてしまう

この状態の訂正を行った

# why
不要な情報が表示されてはいけないため

# Comment
正常に画像のキャッシュを残す実装が非常に難しいため、
未入力のものがある状態で、変更ボタンを押した際、
修正した箇所はすべて反映されずに元のデータが残る実装にいたしました。

【実装動画】
https://gyazo.com/f4db4013db704b1b88d8c6b5ca51603a

